### PR TITLE
Map jvm-wide proxy settings to CXF conduit used for AS4 transmissions

### DIFF
--- a/oxalis-ng-extension/oxalis-ng-as4/src/main/java/network/oxalis/ng/as4/outbound/As4MessageSender.java
+++ b/oxalis-ng-extension/oxalis-ng-as4/src/main/java/network/oxalis/ng/as4/outbound/As4MessageSender.java
@@ -185,10 +185,37 @@ public class As4MessageSender {
         httpClientPolicy.setAllowChunking(true);
         httpClientPolicy.setChunkLength(8192);
         httpClientPolicy.setBrowserType(browserType);
+        configureProxy(httpClientPolicy);
         httpConduit.setClient(httpClientPolicy);
         httpConduit.setTlsClientParameters(tls);
 
         return dispatch;
+    }
+
+    /**
+     * Explicitly configures the CXF {@link HTTPClientPolicy} proxy from JVM system properties.
+     * <p>
+     * Unlike Apache HttpClient (which reads proxy settings via {@code useSystemProperties()}),
+     * CXF's {@link org.apache.cxf.transport.http.HTTPConduit} does not pick up
+     * {@code http.proxyHost} / {@code https.proxyHost} system properties automatically.
+     * This method bridges that gap so that AS4 outbound traffic respects the same proxy
+     * configuration as the rest of the application.
+     * <p>
+     * {@code https.*} properties take precedence over {@code http.*} as AS4 endpoints are HTTPS.
+     */
+    private void configureProxy(HTTPClientPolicy httpClientPolicy) {
+        String proxyHost = System.getProperty("https.proxyHost", System.getProperty("http.proxyHost", ""));
+        String proxyPort = System.getProperty("https.proxyPort", System.getProperty("http.proxyPort", ""));
+        String nonProxyHosts = System.getProperty("https.nonProxyHosts", System.getProperty("http.nonProxyHosts", ""));
+
+        if (!proxyHost.isBlank() && !proxyPort.isBlank()) {
+            log.info("AS4 conduit: configuring proxy {}:{}", proxyHost, proxyPort);
+            httpClientPolicy.setProxyServer(proxyHost);
+            httpClientPolicy.setProxyServerPort(Integer.parseInt(proxyPort));
+            if (!nonProxyHosts.isBlank()) {
+                httpClientPolicy.setNonProxyHosts(nonProxyHosts);
+            }
+        }
     }
 
     private LoggingBeforeSecurityInInterceptor getLoggingBeforeSecurityInInterceptor() {

--- a/oxalis-ng-extension/oxalis-ng-as4/src/test/java/network/oxalis/ng/as4/outbound/As4MessageSenderProxyTest.java
+++ b/oxalis-ng-extension/oxalis-ng-as4/src/test/java/network/oxalis/ng/as4/outbound/As4MessageSenderProxyTest.java
@@ -1,0 +1,131 @@
+package network.oxalis.ng.as4.outbound;
+
+import network.oxalis.ng.as4.api.MessageIdGenerator;
+import network.oxalis.ng.as4.common.MerlinProvider;
+import network.oxalis.ng.as4.config.As4Conf;
+import network.oxalis.ng.as4.util.CompressionUtil;
+import network.oxalis.ng.as4.util.PolicyService;
+import network.oxalis.ng.api.settings.Settings;
+import network.oxalis.ng.commons.http.HttpConf;
+import network.oxalis.ng.commons.security.KeyStoreConf;
+import org.apache.cxf.transports.http.configuration.HTTPClientPolicy;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.lang.reflect.Method;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests that {@link As4MessageSender#configureProxy(HTTPClientPolicy)} correctly maps
+ * JVM proxy system properties to the CXF {@link HTTPClientPolicy}.
+ */
+public class As4MessageSenderProxyTest {
+
+    @Mock private MessagingProvider messagingProvider;
+    @Mock private MessageIdGenerator messageIdGenerator;
+    @Mock private Settings<KeyStoreConf> keyStoreSettings;
+    @Mock private Settings<As4Conf> as4Settings;
+    @Mock private CompressionUtil compressionUtil;
+    @Mock private Settings<HttpConf> httpConfSettings;
+    @Mock private TransmissionResponseConverter responseConverter;
+    @Mock private MerlinProvider merlinProvider;
+    @Mock private PolicyService policyService;
+    @Mock private BrowserTypeProvider browserTypeProvider;
+
+    private As4MessageSender sender;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+        when(browserTypeProvider.getBrowserType()).thenReturn("Oxalis-NG");
+        sender = new As4MessageSender(
+                messagingProvider, messageIdGenerator, keyStoreSettings,
+                as4Settings, compressionUtil, httpConfSettings, responseConverter,
+                merlinProvider, policyService, browserTypeProvider);
+    }
+
+    @After
+    public void tearDown() {
+        System.clearProperty("http.proxyHost");
+        System.clearProperty("http.proxyPort");
+        System.clearProperty("https.proxyHost");
+        System.clearProperty("https.proxyPort");
+        System.clearProperty("http.nonProxyHosts");
+        System.clearProperty("https.nonProxyHosts");
+    }
+
+    @Test
+    public void configureProxy_whenHttpsPropertiesSet_appliesProxyToPolicy() throws Exception {
+        System.setProperty("https.proxyHost", "proxy.example.com");
+        System.setProperty("https.proxyPort", "3128");
+        System.setProperty("https.nonProxyHosts", "localhost|127.0.0.1|*.internal");
+
+        HTTPClientPolicy policy = new HTTPClientPolicy();
+        invokeConfigureProxy(policy);
+
+        assertEquals("proxy.example.com", policy.getProxyServer());
+        assertEquals(3128L, (long) policy.getProxyServerPort());
+        assertEquals("localhost|127.0.0.1|*.internal", policy.getNonProxyHosts());
+    }
+
+    @Test
+    public void configureProxy_whenOnlyHttpPropertiesSet_fallsBackToHttp() throws Exception {
+        System.setProperty("http.proxyHost", "http-proxy.example.com");
+        System.setProperty("http.proxyPort", "8080");
+
+        HTTPClientPolicy policy = new HTTPClientPolicy();
+        invokeConfigureProxy(policy);
+
+        assertEquals("http-proxy.example.com", policy.getProxyServer());
+        assertEquals(8080L, (long) policy.getProxyServerPort());
+    }
+
+    @Test
+    public void configureProxy_whenHttpsAndHttpPropertiesSet_httpsProxyTakesPrecedence() throws Exception {
+        System.setProperty("http.proxyHost", "http-proxy.example.com");
+        System.setProperty("http.proxyPort", "8080");
+        System.setProperty("https.proxyHost", "https-proxy.example.com");
+        System.setProperty("https.proxyPort", "3128");
+
+        HTTPClientPolicy policy = new HTTPClientPolicy();
+        invokeConfigureProxy(policy);
+
+        assertEquals("https-proxy.example.com", policy.getProxyServer());
+        assertEquals(3128L, (long) policy.getProxyServerPort());
+    }
+
+    @Test
+    public void configureProxy_whenNoProxyPropertiesSet_leavesProxyUnconfigured() throws Exception {
+        HTTPClientPolicy policy = new HTTPClientPolicy();
+        invokeConfigureProxy(policy);
+
+        assertNull(policy.getProxyServer());
+        assertEquals(0L, (long) policy.getProxyServerPort());
+        assertNull(policy.getNonProxyHosts());
+    }
+
+    @Test
+    public void configureProxy_whenNonProxyHostsNotSet_doesNotSetNonProxyHosts() throws Exception {
+        System.setProperty("https.proxyHost", "proxy.example.com");
+        System.setProperty("https.proxyPort", "3128");
+
+        HTTPClientPolicy policy = new HTTPClientPolicy();
+        invokeConfigureProxy(policy);
+
+        assertEquals("proxy.example.com", policy.getProxyServer());
+        assertNull(policy.getNonProxyHosts());
+    }
+
+    private void invokeConfigureProxy(HTTPClientPolicy policy) throws Exception {
+        Method method = As4MessageSender.class.getDeclaredMethod("configureProxy", HTTPClientPolicy.class);
+        method.setAccessible(true);
+        method.invoke(sender, policy);
+    }
+}
+


### PR DESCRIPTION
## Pull Request Description

Adding configuration for CXF conduit to follow jvm proxy-related properties, so oxalis-ng can be used in a corporate environment that does not allow direct internet access. 
The SMP lookup queries uses Apache HttpClient, and it is already configured to use system properties, so any attempt to configure such properties as `-Dhttps.proxyHost` will result in a partially working access point.

## Type of Pull Request

- [x] New feature/Enhancement - non-breaking change which adds functionality
- [ ] Bug fix 
- [ ] Breaking change (Require Major version change?)

## Type of Change

- [ ] OpenPeppol eDEC Specifications
- [ ] Peppol AS4 Profile specification
- [ ] Peppol Business Envelope specification
- [ ] Peppol Policies specification
- [ ] Peppol eDEC Code Lists specification
- [ ] OpenPeppol Spring/Fall release 
- [x] Oxalis software internal change or enhancement
- [ ] General change

## Pull Request Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas. But did not add unnecessary annotation/comment say @author name etc
- [x] I have checked my code for variable and method name and corrected grammar/spelling mistakes if any
- [x] I have made corresponding changes to the documentation where needed
- [x] My changes generate no new/additional warnings
- [x] My change is not breaking or creating conflict with associated dependencies 
- [x] I have performed a self-review of my own code
- [x] I ran `mvn clean install` before commit and all tests run successfully 
- [x] I conducted basic QA to assure all features are working fine
- [x] My pull request generate no conflicts with `master` branch
- [ ] I requested code review from other team members
