### PR TITLE
Add validation and fail early if a participant identifier is illegal

### DIFF
--- a/oxalis-ng-commons/pom.xml
+++ b/oxalis-ng-commons/pom.xml
@@ -87,6 +87,10 @@
         <!-- Vefa Peppol -->
         <dependency>
             <groupId>network.oxalis.vefa</groupId>
+            <artifactId>peppol-icd</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>network.oxalis.vefa</groupId>
             <artifactId>peppol-lookup</artifactId>
         </dependency>
         <dependency>

--- a/oxalis-ng-commons/src/main/java/network/oxalis/ng/commons/identifier/IcdValidationMode.java
+++ b/oxalis-ng-commons/src/main/java/network/oxalis/ng/commons/identifier/IcdValidationMode.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2010-2018 Norwegian Agency for Public Management and eGovernment (Difi)
+ *
+ * Licensed under the EUPL, Version 1.1 or – as soon they
+ * will be approved by the European Commission - subsequent
+ * versions of the EUPL (the "Licence");
+ *
+ * You may not use this work except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ *
+ * https://joinup.ec.europa.eu/community/eupl/og_page/eupl
+ *
+ * Unless required by applicable law or agreed to in
+ * writing, software distributed under the Licence is
+ * distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied.
+ * See the Licence for the specific language governing
+ * permissions and limitations under the Licence.
+ */
+
+package network.oxalis.ng.commons.identifier;
+
+import java.util.Locale;
+
+/**
+ * Controls how {@link ParticipantIdentifierValidator} reacts to an ICD that is not part of the
+ * Peppol participant identifier scheme code list bundled with vefa-peppol.
+ * <p>
+ * The bundled code list is a snapshot: when a new jurisdiction joins the Peppol network its ICD is
+ * published by OpenPeppol before a vefa-peppol release (and an oxalis-ng upgrade) can pick it up.
+ * The mode lets an access point decide whether such an unknown-but-well-formed ICD should be fatal,
+ * a warning, or ignored. Structural checks (length, {@code icd:organizationId} format, 4-digit
+ * numeric ICD) are always enforced regardless of mode.
+ * <p>
+ * Configured through the {@code oxalis.identifier.icd.validation} setting.
+ *
+ * @since 1.4.0
+ */
+public enum IcdValidationMode {
+
+    /**
+     * An ICD absent from the bundled code list is fatal: the identifier is rejected.
+     */
+    STRICT,
+
+    /**
+     * An ICD absent from the bundled code list is logged as a warning and processing continues.
+     * This is the default: it keeps the signal without rejecting participants from jurisdictions
+     * newer than the bundled code list.
+     */
+    WARN,
+
+    /**
+     * The code list membership check is skipped entirely.
+     */
+    NONE;
+
+    /**
+     * Parses a configuration value into a mode, case-insensitively.
+     *
+     * @param value the raw configuration value
+     * @return the matching mode
+     * @throws IllegalArgumentException if the value does not name a mode, so that a typo in the
+     *                                  configuration fails at startup instead of silently changing
+     *                                  validation behaviour
+     */
+    public static IcdValidationMode of(String value) {
+        try {
+            return valueOf(value.trim().toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException(String.format(
+                    "Unknown ICD validation mode '%s', expected one of STRICT, WARN or NONE.", value), e);
+        }
+    }
+}

--- a/oxalis-ng-commons/src/main/java/network/oxalis/ng/commons/identifier/IdentifierConf.java
+++ b/oxalis-ng-commons/src/main/java/network/oxalis/ng/commons/identifier/IdentifierConf.java
@@ -41,4 +41,13 @@ public enum IdentifierConf {
     @DefaultValue("default")
     MSGID_GENERATOR,
 
+    /**
+     * Reaction to a participant identifier whose ICD is not in the bundled Peppol code list:
+     * STRICT (reject), WARN (log and continue, the default) or NONE (skip the check).
+     * Structural validation (format and length) is always enforced.
+     */
+    @Path("oxalis.identifier.icd.validation")
+    @DefaultValue("WARN")
+    ICD_VALIDATION,
+
 }

--- a/oxalis-ng-commons/src/main/java/network/oxalis/ng/commons/identifier/IdentifierModule.java
+++ b/oxalis-ng-commons/src/main/java/network/oxalis/ng/commons/identifier/IdentifierModule.java
@@ -27,6 +27,8 @@ import com.google.inject.Key;
 import com.google.inject.Provides;
 import com.google.inject.Singleton;
 import com.google.inject.name.Names;
+import jakarta.inject.Inject;
+import lombok.extern.slf4j.Slf4j;
 import network.oxalis.ng.api.identifier.MessageIdGenerator;
 import network.oxalis.ng.api.settings.Settings;
 import network.oxalis.ng.commons.guice.ImplLoader;
@@ -36,6 +38,7 @@ import network.oxalis.ng.commons.guice.OxalisModule;
  * @author erlend
  * @since 4.0.4
  */
+@Slf4j
 public class IdentifierModule extends OxalisModule {
 
     @Override
@@ -47,6 +50,24 @@ public class IdentifierModule extends OxalisModule {
         bindTyped(MessageIdGenerator.class, DefaultMessageIdGenerator.class);
 
         bindSettings(IdentifierConf.class);
+
+        // Applied eagerly so the configured mode is in effect before the first message is processed,
+        // including at call sites reached from objects built outside the injector.
+        bind(IcdValidationConfigurer.class).asEagerSingleton();
+    }
+
+    /**
+     * Pushes the configured {@link IcdValidationMode} into {@link ParticipantIdentifierValidator}
+     * at startup.
+     */
+    static class IcdValidationConfigurer {
+
+        @Inject
+        IcdValidationConfigurer(Settings<IdentifierConf> settings) {
+            IcdValidationMode mode = IcdValidationMode.of(settings.getString(IdentifierConf.ICD_VALIDATION));
+            ParticipantIdentifierValidator.setIcdValidationMode(mode);
+            log.info("Participant identifier ICD validation mode: {}", mode);
+        }
     }
 
     @Provides

--- a/oxalis-ng-commons/src/main/java/network/oxalis/ng/commons/identifier/ParticipantIdentifierValidator.java
+++ b/oxalis-ng-commons/src/main/java/network/oxalis/ng/commons/identifier/ParticipantIdentifierValidator.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2010-2018 Norwegian Agency for Public Management and eGovernment (Difi)
+ *
+ * Licensed under the EUPL, Version 1.1 or – as soon they
+ * will be approved by the European Commission - subsequent
+ * versions of the EUPL (the "Licence");
+ *
+ * You may not use this work except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ *
+ * https://joinup.ec.europa.eu/community/eupl/og_page/eupl
+ *
+ * Unless required by applicable law or agreed to in
+ * writing, software distributed under the Licence is
+ * distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied.
+ * See the Licence for the specific language governing
+ * permissions and limitations under the Licence.
+ */
+
+package network.oxalis.ng.commons.identifier;
+
+import network.oxalis.vefa.peppol.common.model.ParticipantIdentifier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.regex.Pattern;
+
+/**
+ * Utility for validating Peppol participant identifiers against the expected format.
+ * <p>
+ * A valid Peppol participant identifier value has the form {@code NNNN:orgid} where {@code NNNN} is a 4-digit
+ * ICD code and {@code orgid} is 1 to 130 characters, giving a maximum total length of 135 characters.
+ * <p>
+ * This aligns with the Peppol Policy for Use of Identifiers (PFUOI) v4.4 which increased the maximum
+ * participant identifier value length from 50 to 135 (4 + ":" + 130) characters.
+ *
+ * @since 1.2.3
+ */
+public final class ParticipantIdentifierValidator {
+
+    private static final Logger log = LoggerFactory.getLogger(ParticipantIdentifierValidator.class);
+
+    /**
+     * Maximum length of the organization identifier part (after the ICD and colon),
+     * as defined by PFUOI v4.4.
+     */
+    private static final int MAX_ORG_ID_LENGTH = 130;
+
+    /**
+     * Peppol participant identifier pattern: 4-digit ICD code, colon, then 1 to 130 characters.
+     * Aligns with PFUOI v4.4 and {@code PeppolIdentifierHelper.MAX_PARTICIPANT_VALUE_LENGTH} (= 135).
+     */
+    private static final Pattern PARTICIPANT_ID_PATTERN = Pattern.compile("^\\d{4}:.{1," + MAX_ORG_ID_LENGTH + "}$");
+
+    /**
+     * Maximum total length of a Peppol participant identifier value: 4 (ICD) + 1 (:) + 130 (org-id) = 135.
+     */
+    private static final int MAX_PARTICIPANT_VALUE_LENGTH = 4 + 1 + MAX_ORG_ID_LENGTH;
+
+    private ParticipantIdentifierValidator() {
+        // utility class
+    }
+
+    /**
+     * Checks whether the given participant identifier conforms to the ISO 6523 format.
+     *
+     * @param participantId the participant identifier to validate, may be {@code null}
+     * @return {@code true} if valid or {@code null}, {@code false} otherwise
+     */
+    public static boolean isValid(ParticipantIdentifier participantId) {
+        if (participantId == null) {
+            return true;
+        }
+        var identifier = participantId.getIdentifier();
+        return identifier == null || PARTICIPANT_ID_PATTERN.matcher(identifier).matches();
+    }
+
+    /**
+     * Validates a participant identifier and logs a warning if it does not conform to ISO 6523.
+     *
+     * @param role          a label for the participant role (e.g. "sender", "receiver") used in log messages
+     * @param participantId the participant identifier to validate, may be {@code null}
+     * @return {@code true} if valid or {@code null}, {@code false} if invalid (a warning is logged)
+     */
+    public static boolean validateAndWarn(String role, ParticipantIdentifier participantId) {
+        if (isValid(participantId)) {
+            return true;
+        }
+        var identifier = participantId.getIdentifier();
+        log.warn("Invalid {} participant identifier '{}' (length={}) — "
+                        + "expected format is 'NNNN:orgid' with max {} characters total",
+                role, identifier, identifier.length(), MAX_PARTICIPANT_VALUE_LENGTH);
+        return false;
+    }
+
+    /**
+     * Returns a human-readable error message for an invalid participant identifier.
+     *
+     * @param role       a label for the participant role (e.g. "sender", "receiver")
+     * @param identifier the raw identifier string
+     * @return formatted error message
+     */
+    public static String errorMessage(String role, String identifier) {
+        return String.format(
+                "Invalid %s participant identifier '%s' — does not conform to expected Peppol format "
+                        + "(expected 4-digit ICD, colon, 1-%d char org id, max %d characters total)",
+                role, identifier, MAX_ORG_ID_LENGTH, MAX_PARTICIPANT_VALUE_LENGTH);
+    }
+}
+

--- a/oxalis-ng-commons/src/main/java/network/oxalis/ng/commons/identifier/ParticipantIdentifierValidator.java
+++ b/oxalis-ng-commons/src/main/java/network/oxalis/ng/commons/identifier/ParticipantIdentifierValidator.java
@@ -22,31 +22,41 @@
 
 package network.oxalis.ng.commons.identifier;
 
+import lombok.extern.slf4j.Slf4j;
 import network.oxalis.vefa.peppol.common.lang.PeppolParsingException;
 import network.oxalis.vefa.peppol.common.model.Header;
 import network.oxalis.vefa.peppol.common.model.ParticipantIdentifier;
 import network.oxalis.vefa.peppol.icd.Icds;
 import network.oxalis.vefa.peppol.icd.code.PeppolIcd;
 
+import java.util.Objects;
+import java.util.regex.Pattern;
+
 /**
  * Central entry point for validating the Peppol participant identifiers carried by an SBDH header.
  * <p>
  * Validation is intentionally lightweight and does not attempt full ISO 6523 semantic validation
- * (e.g. organisation-number check digits). It verifies that a participant identifier value:
+ * (e.g. organisation-number check digits). Two tiers of checks are applied:
  * <ul>
- *     <li>has the structural form {@code icd:organizationId} with a non-empty organisation identifier;</li>
- *     <li>carries an ICD that is part of the Peppol participant identifier scheme code list, by delegating
- *     to vefa-peppol's {@link Icds} rather than a hand-rolled regular expression;</li>
- *     <li>does not exceed the maximum length of {@value #MAX_PARTICIPANT_VALUE_LENGTH} characters defined by
- *     the Peppol Policy for use of Identifiers (PFUOI) v4.4 (4-digit ICD + {@code ':'} + up to 130 characters).</li>
+ *     <li><b>Structural checks, always fatal.</b> The value must have the form
+ *     {@code icd:organizationId} with a 4-digit numeric ICD and a non-empty organisation identifier,
+ *     and must not exceed {@value #MAX_PARTICIPANT_VALUE_LENGTH} characters as defined by the Peppol
+ *     Policy for use of Identifiers (PFUOI) v4.4 (4-digit ICD + {@code ':'} + up to 130 characters).
+ *     These rules come from the policy itself and can never reject a legitimate identifier.</li>
+ *     <li><b>ICD code list membership, mode-controlled.</b> The ICD is looked up in the Peppol
+ *     participant identifier scheme code list bundled with vefa-peppol ({@link Icds} over
+ *     {@link PeppolIcd}). That list is a snapshot that can lag behind OpenPeppol publications when a
+ *     new jurisdiction joins the network, so the reaction to an unknown ICD is governed by the
+ *     configured {@link IcdValidationMode} (default {@link IcdValidationMode#WARN}: log and
+ *     continue).</li>
  * </ul>
  * <p>
  * A failing identifier is reported by throwing a {@link PeppolParsingException}: callers treat an invalid
- * identifier as fatal and abort processing, so validation is deliberately not a "log a warning and continue"
- * operation.
+ * identifier as fatal and abort processing.
  *
  * @since 1.2.3
  */
+@Slf4j
 public final class ParticipantIdentifierValidator {
 
     /**
@@ -56,12 +66,41 @@ public final class ParticipantIdentifierValidator {
     public static final int MAX_PARTICIPANT_VALUE_LENGTH = 135;
 
     /**
+     * The ICD part of a participant identifier is always a 4-digit numeric code (ISO 6523).
+     */
+    private static final Pattern ICD_PATTERN = Pattern.compile("[0-9]{4}");
+
+    /**
      * vefa-peppol registry of the officially recognised Peppol participant identifier scheme (ICD) codes.
      */
     private static final Icds ICDS = Icds.of(PeppolIcd.values());
 
+    /**
+     * Reaction to an ICD absent from the bundled code list. Set once at startup by
+     * {@link IdentifierModule} from the {@code oxalis.identifier.icd.validation} setting; the field
+     * is static because validation is also reached from objects built outside the injector (e.g.
+     * the document sniffer's SBDH representation).
+     */
+    private static volatile IcdValidationMode icdValidationMode = IcdValidationMode.WARN;
+
     private ParticipantIdentifierValidator() {
         // utility class
+    }
+
+    /**
+     * Sets the reaction to an ICD that is not part of the bundled Peppol code list.
+     *
+     * @param mode the mode to apply from now on
+     */
+    public static void setIcdValidationMode(IcdValidationMode mode) {
+        icdValidationMode = Objects.requireNonNull(mode, "mode");
+    }
+
+    /**
+     * @return the currently applied reaction to an ICD absent from the bundled code list
+     */
+    public static IcdValidationMode getIcdValidationMode() {
+        return icdValidationMode;
     }
 
     /**
@@ -113,10 +152,26 @@ public final class ParticipantIdentifierValidator {
                     "expected format 'icd:organizationId' with a non-empty organisation identifier"));
         }
 
+        if (!ICD_PATTERN.matcher(identifier.substring(0, separator)).matches()) {
+            throw new PeppolParsingException(errorMessage(role, identifier,
+                    "the ICD part must be a 4-digit numeric code"));
+        }
+
+        if (icdValidationMode == IcdValidationMode.NONE) {
+            return;
+        }
+
         try {
             ICDS.parse(participantId);
         } catch (PeppolParsingException e) {
-            throw new PeppolParsingException(errorMessage(role, identifier, e.getMessage()), e);
+            if (icdValidationMode == IcdValidationMode.STRICT) {
+                throw new PeppolParsingException(errorMessage(role, identifier, e.getMessage()), e);
+            }
+            // WARN: the ICD is well-formed but not in the bundled code list. It may belong to a
+            // jurisdiction newer than this build, so keep processing instead of rejecting.
+            log.warn("The {} participant identifier '{}' uses an ICD that is not in the bundled Peppol "
+                            + "code list ({}). Accepting it; set oxalis.identifier.icd.validation=STRICT to reject.",
+                    role, identifier, e.getMessage());
         }
     }
 

--- a/oxalis-ng-commons/src/main/java/network/oxalis/ng/commons/identifier/ParticipantIdentifierValidator.java
+++ b/oxalis-ng-commons/src/main/java/network/oxalis/ng/commons/identifier/ParticipantIdentifierValidator.java
@@ -22,92 +22,121 @@
 
 package network.oxalis.ng.commons.identifier;
 
+import network.oxalis.vefa.peppol.common.lang.PeppolParsingException;
+import network.oxalis.vefa.peppol.common.model.Header;
 import network.oxalis.vefa.peppol.common.model.ParticipantIdentifier;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.util.regex.Pattern;
+import network.oxalis.vefa.peppol.icd.Icds;
+import network.oxalis.vefa.peppol.icd.code.PeppolIcd;
 
 /**
- * Utility for validating Peppol participant identifiers against the expected format.
+ * Central entry point for validating the Peppol participant identifiers carried by an SBDH header.
  * <p>
- * A valid Peppol participant identifier value has the form {@code NNNN:orgid} where {@code NNNN} is a 4-digit
- * ICD code and {@code orgid} is 1 to 130 characters, giving a maximum total length of 135 characters.
+ * Validation is intentionally lightweight and does not attempt full ISO 6523 semantic validation
+ * (e.g. organisation-number check digits). It verifies that a participant identifier value:
+ * <ul>
+ *     <li>has the structural form {@code icd:organizationId} with a non-empty organisation identifier;</li>
+ *     <li>carries an ICD that is part of the Peppol participant identifier scheme code list, by delegating
+ *     to vefa-peppol's {@link Icds} rather than a hand-rolled regular expression;</li>
+ *     <li>does not exceed the maximum length of {@value #MAX_PARTICIPANT_VALUE_LENGTH} characters defined by
+ *     the Peppol Policy for use of Identifiers (PFUOI) v4.4 (4-digit ICD + {@code ':'} + up to 130 characters).</li>
+ * </ul>
  * <p>
- * This aligns with the Peppol Policy for Use of Identifiers (PFUOI) v4.4 which increased the maximum
- * participant identifier value length from 50 to 135 (4 + ":" + 130) characters.
+ * A failing identifier is reported by throwing a {@link PeppolParsingException}: callers treat an invalid
+ * identifier as fatal and abort processing, so validation is deliberately not a "log a warning and continue"
+ * operation.
  *
  * @since 1.2.3
  */
 public final class ParticipantIdentifierValidator {
 
-    private static final Logger log = LoggerFactory.getLogger(ParticipantIdentifierValidator.class);
+    /**
+     * Maximum total length of a Peppol participant identifier value as defined by PFUOI v4.4:
+     * 4 (ICD) + 1 ({@code ':'}) + 130 (organisation id) = 135 characters.
+     */
+    public static final int MAX_PARTICIPANT_VALUE_LENGTH = 135;
 
     /**
-     * Maximum length of the organization identifier part (after the ICD and colon),
-     * as defined by PFUOI v4.4.
+     * vefa-peppol registry of the officially recognised Peppol participant identifier scheme (ICD) codes.
      */
-    private static final int MAX_ORG_ID_LENGTH = 130;
-
-    /**
-     * Peppol participant identifier pattern: 4-digit ICD code, colon, then 1 to 130 characters.
-     * Aligns with PFUOI v4.4 and {@code PeppolIdentifierHelper.MAX_PARTICIPANT_VALUE_LENGTH} (= 135).
-     */
-    private static final Pattern PARTICIPANT_ID_PATTERN = Pattern.compile("^\\d{4}:.{1," + MAX_ORG_ID_LENGTH + "}$");
-
-    /**
-     * Maximum total length of a Peppol participant identifier value: 4 (ICD) + 1 (:) + 130 (org-id) = 135.
-     */
-    private static final int MAX_PARTICIPANT_VALUE_LENGTH = 4 + 1 + MAX_ORG_ID_LENGTH;
+    private static final Icds ICDS = Icds.of(PeppolIcd.values());
 
     private ParticipantIdentifierValidator() {
         // utility class
     }
 
     /**
-     * Checks whether the given participant identifier conforms to the ISO 6523 format.
+     * Validates the sender and receiver participant identifiers of the given header.
+     *
+     * @param header the parsed SBDH header
+     * @throws PeppolParsingException if the sender or receiver participant identifier is invalid
+     */
+    public static void validate(Header header) throws PeppolParsingException {
+        validate(header.getSender(), header.getReceiver());
+    }
+
+    /**
+     * Validates a sender/receiver pair of participant identifiers.
+     *
+     * @param sender   the sender participant identifier, may be {@code null}
+     * @param receiver the receiver participant identifier, may be {@code null}
+     * @throws PeppolParsingException if either participant identifier is invalid
+     */
+    public static void validate(ParticipantIdentifier sender, ParticipantIdentifier receiver)
+            throws PeppolParsingException {
+        validate("sender", sender);
+        validate("receiver", receiver);
+    }
+
+    /**
+     * Validates a single participant identifier.
+     *
+     * @param role          a label for the participant role (e.g. "sender", "receiver") used in error messages
+     * @param participantId the participant identifier to validate, may be {@code null}
+     * @throws PeppolParsingException if the participant identifier is invalid
+     */
+    public static void validate(String role, ParticipantIdentifier participantId) throws PeppolParsingException {
+        if (participantId == null || participantId.getIdentifier() == null) {
+            return;
+        }
+
+        String identifier = participantId.getIdentifier();
+
+        if (identifier.length() > MAX_PARTICIPANT_VALUE_LENGTH) {
+            throw new PeppolParsingException(errorMessage(role, identifier, String.format(
+                    "value length %d exceeds the maximum of %d characters",
+                    identifier.length(), MAX_PARTICIPANT_VALUE_LENGTH)));
+        }
+
+        int separator = identifier.indexOf(':');
+        if (separator < 0 || separator == identifier.length() - 1) {
+            throw new PeppolParsingException(errorMessage(role, identifier,
+                    "expected format 'icd:organizationId' with a non-empty organisation identifier"));
+        }
+
+        try {
+            ICDS.parse(participantId);
+        } catch (PeppolParsingException e) {
+            throw new PeppolParsingException(errorMessage(role, identifier, e.getMessage()), e);
+        }
+    }
+
+    /**
+     * Convenience non-throwing check.
      *
      * @param participantId the participant identifier to validate, may be {@code null}
-     * @return {@code true} if valid or {@code null}, {@code false} otherwise
+     * @return {@code true} if the identifier is valid (or {@code null}), {@code false} otherwise
      */
     public static boolean isValid(ParticipantIdentifier participantId) {
-        if (participantId == null) {
+        try {
+            validate("participant", participantId);
             return true;
+        } catch (PeppolParsingException e) {
+            return false;
         }
-        var identifier = participantId.getIdentifier();
-        return identifier == null || PARTICIPANT_ID_PATTERN.matcher(identifier).matches();
     }
 
-    /**
-     * Validates a participant identifier and logs a warning if it does not conform to ISO 6523.
-     *
-     * @param role          a label for the participant role (e.g. "sender", "receiver") used in log messages
-     * @param participantId the participant identifier to validate, may be {@code null}
-     * @return {@code true} if valid or {@code null}, {@code false} if invalid (a warning is logged)
-     */
-    public static boolean validateAndWarn(String role, ParticipantIdentifier participantId) {
-        if (isValid(participantId)) {
-            return true;
-        }
-        var identifier = participantId.getIdentifier();
-        log.warn("Invalid {} participant identifier '{}' (length={}) — "
-                        + "expected format is 'NNNN:orgid' with max {} characters total",
-                role, identifier, identifier.length(), MAX_PARTICIPANT_VALUE_LENGTH);
-        return false;
-    }
-
-    /**
-     * Returns a human-readable error message for an invalid participant identifier.
-     *
-     * @param role       a label for the participant role (e.g. "sender", "receiver")
-     * @param identifier the raw identifier string
-     * @return formatted error message
-     */
-    public static String errorMessage(String role, String identifier) {
+    private static String errorMessage(String role, String identifier, String reason) {
         return String.format(
-                "Invalid %s participant identifier '%s' — does not conform to expected Peppol format "
-                        + "(expected 4-digit ICD, colon, 1-%d char org id, max %d characters total)",
-                role, identifier, MAX_ORG_ID_LENGTH, MAX_PARTICIPANT_VALUE_LENGTH);
+                "Invalid %s participant identifier '%s': %s", role, identifier, reason);
     }
 }
-

--- a/oxalis-ng-commons/src/test/java/network/oxalis/ng/commons/identifier/ParticipantIdentifierValidatorTest.java
+++ b/oxalis-ng-commons/src/test/java/network/oxalis/ng/commons/identifier/ParticipantIdentifierValidatorTest.java
@@ -1,0 +1,105 @@
+package network.oxalis.ng.commons.identifier;
+
+import network.oxalis.vefa.peppol.common.model.ParticipantIdentifier;
+import network.oxalis.vefa.peppol.common.model.Scheme;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+public class ParticipantIdentifierValidatorTest {
+
+    private static final Scheme DEFAULT_SCHEME = Scheme.of("iso6523-actorid-upis");
+
+    @Test
+    public void validStandardIdentifier() {
+        var id = ParticipantIdentifier.of("0192:987654321", DEFAULT_SCHEME);
+        assertTrue(ParticipantIdentifierValidator.isValid(id));
+        assertTrue(ParticipantIdentifierValidator.validateAndWarn("receiver", id));
+    }
+
+    @Test
+    public void validMaxLengthIdentifier() {
+        // 4-digit ICD + colon + 130 chars = 135 total (maximum allowed per PFUOI v4.4)
+        var orgId = "a".repeat(130);
+        var id = ParticipantIdentifier.of("0192:" + orgId, DEFAULT_SCHEME);
+        assertTrue(ParticipantIdentifierValidator.isValid(id));
+    }
+
+    @Test
+    public void validMinLengthIdentifier() {
+        // 4-digit ICD + colon + 1 char = 6 total (minimum valid)
+        var id = ParticipantIdentifier.of("0192:X", DEFAULT_SCHEME);
+        assertTrue(ParticipantIdentifierValidator.isValid(id));
+    }
+
+    @Test
+    public void validOldMaxLengthStillValid() {
+        // Old max was 28 chars for org-id — should still be valid under new limits
+        var id = ParticipantIdentifier.of("0192:1234567890123456789012345678", DEFAULT_SCHEME);
+        assertTrue(ParticipantIdentifierValidator.isValid(id));
+    }
+
+    @Test
+    public void validLongIdentifierWithinNewLimits() {
+        // 50 chars for org-id — exceeds old limit but valid under PFUOI v4.4
+        var orgId = "a".repeat(50);
+        var id = ParticipantIdentifier.of("0192:" + orgId, DEFAULT_SCHEME);
+        assertTrue(ParticipantIdentifierValidator.isValid(id));
+    }
+
+    @Test
+    public void nullIdentifierIsValid() {
+        assertTrue(ParticipantIdentifierValidator.isValid(null));
+        assertTrue(ParticipantIdentifierValidator.validateAndWarn("sender", null));
+    }
+
+    @Test
+    public void identifierTooLong() {
+        // 4-digit ICD + colon + 131 chars = 136 total (exceeds max of 135)
+        var orgId = "a".repeat(131);
+        var id = ParticipantIdentifier.of("0192:" + orgId, DEFAULT_SCHEME);
+        assertFalse(ParticipantIdentifierValidator.isValid(id));
+        assertFalse(ParticipantIdentifierValidator.validateAndWarn("receiver", id));
+    }
+
+    @Test
+    public void identifierMissingIcdPrefix() {
+        var id = ParticipantIdentifier.of("ABC:987654321", DEFAULT_SCHEME);
+        assertFalse(ParticipantIdentifierValidator.isValid(id));
+    }
+
+    @Test
+    public void identifierMissingColon() {
+        var id = ParticipantIdentifier.of("0192987654321", DEFAULT_SCHEME);
+        assertFalse(ParticipantIdentifierValidator.isValid(id));
+    }
+
+    @Test
+    public void identifierWithEmptyOrgId() {
+        // 4-digit ICD + colon + nothing = invalid
+        var id = ParticipantIdentifier.of("0192:", DEFAULT_SCHEME);
+        assertFalse(ParticipantIdentifierValidator.isValid(id));
+    }
+
+    @Test
+    public void identifierWithThreeDigitIcd() {
+        var id = ParticipantIdentifier.of("019:987654321", DEFAULT_SCHEME);
+        assertFalse(ParticipantIdentifierValidator.isValid(id));
+    }
+
+    @Test
+    public void identifierWithFiveDigitIcd() {
+        var id = ParticipantIdentifier.of("01920:987654321", DEFAULT_SCHEME);
+        assertFalse(ParticipantIdentifierValidator.isValid(id));
+    }
+
+    @Test
+    public void errorMessageContainsRole() {
+        var msg = ParticipantIdentifierValidator.errorMessage("receiver", "bad-id");
+        assertTrue(msg.contains("receiver"));
+        assertTrue(msg.contains("bad-id"));
+        assertTrue(msg.contains("Peppol"));
+    }
+}
+

--- a/oxalis-ng-commons/src/test/java/network/oxalis/ng/commons/identifier/ParticipantIdentifierValidatorTest.java
+++ b/oxalis-ng-commons/src/test/java/network/oxalis/ng/commons/identifier/ParticipantIdentifierValidatorTest.java
@@ -3,8 +3,10 @@ package network.oxalis.ng.commons.identifier;
 import network.oxalis.vefa.peppol.common.lang.PeppolParsingException;
 import network.oxalis.vefa.peppol.common.model.ParticipantIdentifier;
 import network.oxalis.vefa.peppol.common.model.Scheme;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.Test;
 
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertThrows;
 import static org.testng.Assert.assertTrue;
@@ -16,6 +18,11 @@ public class ParticipantIdentifierValidatorTest {
 
     private static ParticipantIdentifier id(String value) {
         return ParticipantIdentifier.of(value, DEFAULT_SCHEME);
+    }
+
+    @AfterMethod
+    public void resetIcdValidationMode() {
+        ParticipantIdentifierValidator.setIcdValidationMode(IcdValidationMode.WARN);
     }
 
     @Test
@@ -61,9 +68,46 @@ public class ParticipantIdentifierValidatorTest {
     }
 
     @Test
-    public void identifierWithUnknownIcd() {
-        // ICD 9999 is not part of the Peppol participant identifier scheme code list
+    public void unknownIcdIsAcceptedByDefault() {
+        // ICD 9999 is not part of the bundled Peppol code list, but the code list is a snapshot
+        // that can lag behind newly onboarded jurisdictions — the default WARN mode accepts it.
+        assertEquals(ParticipantIdentifierValidator.getIcdValidationMode(), IcdValidationMode.WARN);
+        assertTrue(ParticipantIdentifierValidator.isValid(id("9999:987654321")));
+    }
+
+    @Test
+    public void unknownIcdIsRejectedInStrictMode() {
+        ParticipantIdentifierValidator.setIcdValidationMode(IcdValidationMode.STRICT);
         assertFalse(ParticipantIdentifierValidator.isValid(id("9999:987654321")));
+
+        var ex = expectThrows(PeppolParsingException.class,
+                () -> ParticipantIdentifierValidator.validate("receiver", id("9999:987654321")));
+        assertTrue(ex.getMessage().contains("receiver"));
+        assertTrue(ex.getMessage().contains("9999:987654321"));
+    }
+
+    @Test
+    public void knownIcdIsAcceptedInStrictMode() throws PeppolParsingException {
+        ParticipantIdentifierValidator.setIcdValidationMode(IcdValidationMode.STRICT);
+        ParticipantIdentifierValidator.validate("receiver", id("0192:987654321"));
+    }
+
+    @Test
+    public void unknownIcdIsAcceptedInNoneMode() {
+        ParticipantIdentifierValidator.setIcdValidationMode(IcdValidationMode.NONE);
+        assertTrue(ParticipantIdentifierValidator.isValid(id("9999:987654321")));
+    }
+
+    @Test
+    public void structuralChecksApplyInEveryMode() {
+        // Format and length come from the Peppol policy itself, not the code list snapshot,
+        // so they stay fatal even when the code list check is disabled.
+        for (IcdValidationMode mode : IcdValidationMode.values()) {
+            ParticipantIdentifierValidator.setIcdValidationMode(mode);
+            assertFalse(ParticipantIdentifierValidator.isValid(id("abc:987654321")), "mode " + mode);
+            assertFalse(ParticipantIdentifierValidator.isValid(id("0192:")), "mode " + mode);
+            assertFalse(ParticipantIdentifierValidator.isValid(id("0192:" + "a".repeat(131))), "mode " + mode);
+        }
     }
 
     @Test
@@ -94,8 +138,20 @@ public class ParticipantIdentifierValidatorTest {
     @Test
     public void invalidIdentifierMessageContainsRoleAndValue() {
         var ex = expectThrows(PeppolParsingException.class,
-                () -> ParticipantIdentifierValidator.validate("receiver", id("9999:bad-id")));
+                () -> ParticipantIdentifierValidator.validate("receiver", id("abc:bad-id")));
         assertTrue(ex.getMessage().contains("receiver"));
-        assertTrue(ex.getMessage().contains("9999:bad-id"));
+        assertTrue(ex.getMessage().contains("abc:bad-id"));
+    }
+
+    @Test
+    public void modeParsingIsCaseInsensitive() {
+        assertEquals(IcdValidationMode.of("strict"), IcdValidationMode.STRICT);
+        assertEquals(IcdValidationMode.of(" Warn "), IcdValidationMode.WARN);
+        assertEquals(IcdValidationMode.of("NONE"), IcdValidationMode.NONE);
+    }
+
+    @Test
+    public void unknownModeFailsFast() {
+        assertThrows(IllegalArgumentException.class, () -> IcdValidationMode.of("lenient"));
     }
 }

--- a/oxalis-ng-commons/src/test/java/network/oxalis/ng/commons/identifier/ParticipantIdentifierValidatorTest.java
+++ b/oxalis-ng-commons/src/test/java/network/oxalis/ng/commons/identifier/ParticipantIdentifierValidatorTest.java
@@ -1,105 +1,101 @@
 package network.oxalis.ng.commons.identifier;
 
+import network.oxalis.vefa.peppol.common.lang.PeppolParsingException;
 import network.oxalis.vefa.peppol.common.model.ParticipantIdentifier;
 import network.oxalis.vefa.peppol.common.model.Scheme;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertThrows;
 import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.expectThrows;
 
 public class ParticipantIdentifierValidatorTest {
 
     private static final Scheme DEFAULT_SCHEME = Scheme.of("iso6523-actorid-upis");
 
+    private static ParticipantIdentifier id(String value) {
+        return ParticipantIdentifier.of(value, DEFAULT_SCHEME);
+    }
+
     @Test
-    public void validStandardIdentifier() {
-        var id = ParticipantIdentifier.of("0192:987654321", DEFAULT_SCHEME);
-        assertTrue(ParticipantIdentifierValidator.isValid(id));
-        assertTrue(ParticipantIdentifierValidator.validateAndWarn("receiver", id));
+    public void validStandardIdentifier() throws PeppolParsingException {
+        // 0192 = NO:ORG, a recognised Peppol ICD
+        ParticipantIdentifierValidator.validate("receiver", id("0192:987654321"));
+        assertTrue(ParticipantIdentifierValidator.isValid(id("0192:987654321")));
     }
 
     @Test
     public void validMaxLengthIdentifier() {
         // 4-digit ICD + colon + 130 chars = 135 total (maximum allowed per PFUOI v4.4)
         var orgId = "a".repeat(130);
-        var id = ParticipantIdentifier.of("0192:" + orgId, DEFAULT_SCHEME);
-        assertTrue(ParticipantIdentifierValidator.isValid(id));
+        assertTrue(ParticipantIdentifierValidator.isValid(id("0192:" + orgId)));
     }
 
     @Test
     public void validMinLengthIdentifier() {
-        // 4-digit ICD + colon + 1 char = 6 total (minimum valid)
-        var id = ParticipantIdentifier.of("0192:X", DEFAULT_SCHEME);
-        assertTrue(ParticipantIdentifierValidator.isValid(id));
-    }
-
-    @Test
-    public void validOldMaxLengthStillValid() {
-        // Old max was 28 chars for org-id — should still be valid under new limits
-        var id = ParticipantIdentifier.of("0192:1234567890123456789012345678", DEFAULT_SCHEME);
-        assertTrue(ParticipantIdentifierValidator.isValid(id));
+        // 4-digit ICD + colon + 1 char (minimum valid organisation id)
+        assertTrue(ParticipantIdentifierValidator.isValid(id("0192:x")));
     }
 
     @Test
     public void validLongIdentifierWithinNewLimits() {
-        // 50 chars for org-id — exceeds old limit but valid under PFUOI v4.4
+        // 50 chars for org-id — exceeds the old 28/50 limit but valid under PFUOI v4.4
         var orgId = "a".repeat(50);
-        var id = ParticipantIdentifier.of("0192:" + orgId, DEFAULT_SCHEME);
-        assertTrue(ParticipantIdentifierValidator.isValid(id));
+        assertTrue(ParticipantIdentifierValidator.isValid(id("0192:" + orgId)));
     }
 
     @Test
-    public void nullIdentifierIsValid() {
+    public void nullIdentifierIsValid() throws PeppolParsingException {
         assertTrue(ParticipantIdentifierValidator.isValid(null));
-        assertTrue(ParticipantIdentifierValidator.validateAndWarn("sender", null));
+        ParticipantIdentifierValidator.validate("sender", null);
     }
 
     @Test
     public void identifierTooLong() {
         // 4-digit ICD + colon + 131 chars = 136 total (exceeds max of 135)
         var orgId = "a".repeat(131);
-        var id = ParticipantIdentifier.of("0192:" + orgId, DEFAULT_SCHEME);
-        assertFalse(ParticipantIdentifierValidator.isValid(id));
-        assertFalse(ParticipantIdentifierValidator.validateAndWarn("receiver", id));
+        assertFalse(ParticipantIdentifierValidator.isValid(id("0192:" + orgId)));
+        assertThrows(PeppolParsingException.class,
+                () -> ParticipantIdentifierValidator.validate("receiver", id("0192:" + orgId)));
+    }
+
+    @Test
+    public void identifierWithUnknownIcd() {
+        // ICD 9999 is not part of the Peppol participant identifier scheme code list
+        assertFalse(ParticipantIdentifierValidator.isValid(id("9999:987654321")));
     }
 
     @Test
     public void identifierMissingIcdPrefix() {
-        var id = ParticipantIdentifier.of("ABC:987654321", DEFAULT_SCHEME);
-        assertFalse(ParticipantIdentifierValidator.isValid(id));
+        assertFalse(ParticipantIdentifierValidator.isValid(id("abc:987654321")));
     }
 
     @Test
     public void identifierMissingColon() {
-        var id = ParticipantIdentifier.of("0192987654321", DEFAULT_SCHEME);
-        assertFalse(ParticipantIdentifierValidator.isValid(id));
+        assertFalse(ParticipantIdentifierValidator.isValid(id("0192987654321")));
     }
 
     @Test
     public void identifierWithEmptyOrgId() {
-        // 4-digit ICD + colon + nothing = invalid
-        var id = ParticipantIdentifier.of("0192:", DEFAULT_SCHEME);
-        assertFalse(ParticipantIdentifierValidator.isValid(id));
+        assertFalse(ParticipantIdentifierValidator.isValid(id("0192:")));
     }
 
     @Test
     public void identifierWithThreeDigitIcd() {
-        var id = ParticipantIdentifier.of("019:987654321", DEFAULT_SCHEME);
-        assertFalse(ParticipantIdentifierValidator.isValid(id));
+        assertFalse(ParticipantIdentifierValidator.isValid(id("019:987654321")));
     }
 
     @Test
     public void identifierWithFiveDigitIcd() {
-        var id = ParticipantIdentifier.of("01920:987654321", DEFAULT_SCHEME);
-        assertFalse(ParticipantIdentifierValidator.isValid(id));
+        assertFalse(ParticipantIdentifierValidator.isValid(id("01920:987654321")));
     }
 
     @Test
-    public void errorMessageContainsRole() {
-        var msg = ParticipantIdentifierValidator.errorMessage("receiver", "bad-id");
-        assertTrue(msg.contains("receiver"));
-        assertTrue(msg.contains("bad-id"));
-        assertTrue(msg.contains("Peppol"));
+    public void invalidIdentifierMessageContainsRoleAndValue() {
+        var ex = expectThrows(PeppolParsingException.class,
+                () -> ParticipantIdentifierValidator.validate("receiver", id("9999:bad-id")));
+        assertTrue(ex.getMessage().contains("receiver"));
+        assertTrue(ex.getMessage().contains("9999:bad-id"));
     }
 }
-

--- a/oxalis-ng-legacy/oxalis-ng-document-sniffer/src/main/java/network/oxalis/ng/sniffer/PeppolStandardBusinessHeader.java
+++ b/oxalis-ng-legacy/oxalis-ng-document-sniffer/src/main/java/network/oxalis/ng/sniffer/PeppolStandardBusinessHeader.java
@@ -22,6 +22,7 @@
 
 package network.oxalis.ng.sniffer;
 
+import network.oxalis.ng.commons.identifier.ParticipantIdentifierValidator;
 import network.oxalis.ng.sniffer.identifier.InstanceId;
 import network.oxalis.ng.sniffer.identifier.PeppolDocumentTypeId;
 import network.oxalis.vefa.peppol.common.lang.PeppolParsingException;
@@ -31,6 +32,7 @@ import org.apache.commons.lang3.StringUtils;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.regex.Pattern;
 
 /**
  * Our representation of the SBDH (Standard Business Document Header), which makes us
@@ -42,6 +44,7 @@ import java.util.List;
  * @author thore
  */
 public class PeppolStandardBusinessHeader {
+
 
     /**
      * Peppol Participant Identification for the recipient
@@ -179,6 +182,15 @@ public class PeppolStandardBusinessHeader {
      */
     public void validateHeaderFields() throws PeppolParsingException {
         try {
+            if (!ParticipantIdentifierValidator.validateAndWarn("sender", senderId)) {
+                throw new PeppolParsingException(
+                        ParticipantIdentifierValidator.errorMessage("sender", senderId.getIdentifier()));
+            }
+            if (!ParticipantIdentifierValidator.validateAndWarn("receiver", recipientId)) {
+                throw new PeppolParsingException(
+                        ParticipantIdentifierValidator.errorMessage("receiver", recipientId.getIdentifier()));
+            }
+
             DocumentTypeIdentifier documentTypeIdentifier =
                     DocumentTypeIdentifier.parse(peppolDocumentTypeId.toString());
             if (documentTypeIdentifier.getScheme() == null

--- a/oxalis-ng-legacy/oxalis-ng-document-sniffer/src/main/java/network/oxalis/ng/sniffer/PeppolStandardBusinessHeader.java
+++ b/oxalis-ng-legacy/oxalis-ng-document-sniffer/src/main/java/network/oxalis/ng/sniffer/PeppolStandardBusinessHeader.java
@@ -32,7 +32,6 @@ import org.apache.commons.lang3.StringUtils;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
-import java.util.regex.Pattern;
 
 /**
  * Our representation of the SBDH (Standard Business Document Header), which makes us
@@ -44,7 +43,6 @@ import java.util.regex.Pattern;
  * @author thore
  */
 public class PeppolStandardBusinessHeader {
-
 
     /**
      * Peppol Participant Identification for the recipient
@@ -182,14 +180,7 @@ public class PeppolStandardBusinessHeader {
      */
     public void validateHeaderFields() throws PeppolParsingException {
         try {
-            if (!ParticipantIdentifierValidator.validateAndWarn("sender", senderId)) {
-                throw new PeppolParsingException(
-                        ParticipantIdentifierValidator.errorMessage("sender", senderId.getIdentifier()));
-            }
-            if (!ParticipantIdentifierValidator.validateAndWarn("receiver", recipientId)) {
-                throw new PeppolParsingException(
-                        ParticipantIdentifierValidator.errorMessage("receiver", recipientId.getIdentifier()));
-            }
+            ParticipantIdentifierValidator.validate(senderId, recipientId);
 
             DocumentTypeIdentifier documentTypeIdentifier =
                     DocumentTypeIdentifier.parse(peppolDocumentTypeId.toString());

--- a/oxalis-ng-outbound/src/main/java/network/oxalis/ng/outbound/transmission/TransmissionRequestFactory.java
+++ b/oxalis-ng-outbound/src/main/java/network/oxalis/ng/outbound/transmission/TransmissionRequestFactory.java
@@ -32,6 +32,7 @@ import network.oxalis.ng.api.tag.Tag;
 import network.oxalis.ng.api.tag.TagGenerator;
 import network.oxalis.ng.api.transformer.ContentDetector;
 import network.oxalis.ng.api.transformer.ContentWrapper;
+import network.oxalis.ng.commons.identifier.ParticipantIdentifierValidator;
 import network.oxalis.ng.commons.io.PeekingInputStream;
 import network.oxalis.ng.commons.tracing.Traceable;
 import network.oxalis.vefa.peppol.common.model.Header;
@@ -46,6 +47,7 @@ import java.io.InputStream;
  * @since 4.0.0
  */
 public class TransmissionRequestFactory extends Traceable {
+
 
     private final ContentDetector contentDetector;
 
@@ -85,11 +87,13 @@ public class TransmissionRequestFactory extends Traceable {
         PeekingInputStream peekingInputStream = new PeekingInputStream(inputStream);
         try {
             Header header = readHeaderFromSbdh(peekingInputStream);
+            validateParticipantIdentifiers(header);
             return new DefaultTransmissionMessage(header, peekingInputStream.newInputStream(),
                     tagGenerator.generate(Direction.OUT, tag));
         } catch (OxalisContentException e) {
             byte[] payload = peekingInputStream.getContent();
             Header header = detectHeaderFromContent(payload);
+            validateParticipantIdentifiers(header);
             InputStream wrappedContent = wrapContentInSbdh(header, payload);
             return new DefaultTransmissionMessage(header, wrappedContent, tagGenerator.generate(Direction.OUT, tag));
         }
@@ -133,6 +137,24 @@ public class TransmissionRequestFactory extends Traceable {
             throw e;
         } finally {
             span.end();
+        }
+    }
+
+    /**
+     * Validates that sender and receiver participant identifiers conform to ISO 6523 format.
+     * Rejects the message early if identifiers are malformed, preventing downstream persistence errors.
+     *
+     * @param header the parsed SBDH header
+     * @throws OxalisContentException if any participant identifier is invalid
+     */
+    private void validateParticipantIdentifiers(Header header) throws OxalisContentException {
+        if (!ParticipantIdentifierValidator.validateAndWarn("sender", header.getSender())) {
+            throw new OxalisContentException(
+                    ParticipantIdentifierValidator.errorMessage("sender", header.getSender().getIdentifier()));
+        }
+        if (!ParticipantIdentifierValidator.validateAndWarn("receiver", header.getReceiver())) {
+            throw new OxalisContentException(
+                    ParticipantIdentifierValidator.errorMessage("receiver", header.getReceiver().getIdentifier()));
         }
     }
 }

--- a/oxalis-ng-outbound/src/main/java/network/oxalis/ng/outbound/transmission/TransmissionRequestFactory.java
+++ b/oxalis-ng-outbound/src/main/java/network/oxalis/ng/outbound/transmission/TransmissionRequestFactory.java
@@ -35,6 +35,7 @@ import network.oxalis.ng.api.transformer.ContentWrapper;
 import network.oxalis.ng.commons.identifier.ParticipantIdentifierValidator;
 import network.oxalis.ng.commons.io.PeekingInputStream;
 import network.oxalis.ng.commons.tracing.Traceable;
+import network.oxalis.vefa.peppol.common.lang.PeppolParsingException;
 import network.oxalis.vefa.peppol.common.model.Header;
 
 import jakarta.inject.Inject;
@@ -47,7 +48,6 @@ import java.io.InputStream;
  * @since 4.0.0
  */
 public class TransmissionRequestFactory extends Traceable {
-
 
     private final ContentDetector contentDetector;
 
@@ -141,20 +141,18 @@ public class TransmissionRequestFactory extends Traceable {
     }
 
     /**
-     * Validates that sender and receiver participant identifiers conform to ISO 6523 format.
-     * Rejects the message early if identifiers are malformed, preventing downstream persistence errors.
+     * Validates that the sender and receiver participant identifiers of the header are well-formed
+     * before the message is accepted. Rejecting malformed identifiers early prevents downstream
+     * persistence errors.
      *
      * @param header the parsed SBDH header
      * @throws OxalisContentException if any participant identifier is invalid
      */
     private void validateParticipantIdentifiers(Header header) throws OxalisContentException {
-        if (!ParticipantIdentifierValidator.validateAndWarn("sender", header.getSender())) {
-            throw new OxalisContentException(
-                    ParticipantIdentifierValidator.errorMessage("sender", header.getSender().getIdentifier()));
-        }
-        if (!ParticipantIdentifierValidator.validateAndWarn("receiver", header.getReceiver())) {
-            throw new OxalisContentException(
-                    ParticipantIdentifierValidator.errorMessage("receiver", header.getReceiver().getIdentifier()));
+        try {
+            ParticipantIdentifierValidator.validate(header);
+        } catch (PeppolParsingException e) {
+            throw new OxalisContentException(e.getMessage(), e);
         }
     }
 }

--- a/oxalis-ng-outbound/src/test/resources/peppol-bis-invoice-sbdh.xml
+++ b/oxalis-ng-outbound/src/test/resources/peppol-bis-invoice-sbdh.xml
@@ -25,7 +25,7 @@
     <StandardBusinessDocumentHeader>
         <HeaderVersion>1.0</HeaderVersion>
         <Sender>
-            <Identifier Authority="iso6523-actorid-upis">9908:976098897</Identifier>
+            <Identifier Authority="iso6523-actorid-upis">0192:976098897</Identifier>
         </Sender>
         <Receiver>
             <Identifier Authority="iso6523-actorid-upis">0192:923829644</Identifier>

--- a/oxalis-ng-test/src/main/java/network/oxalis/ng/test/identifier/WellKnownParticipant.java
+++ b/oxalis-ng-test/src/main/java/network/oxalis/ng/test/identifier/WellKnownParticipant.java
@@ -31,15 +31,15 @@ import network.oxalis.vefa.peppol.common.model.ParticipantIdentifier;
  */
 public class WellKnownParticipant {
 
-    public static final ParticipantIdentifier U4_TEST = ParticipantIdentifier.of("9908:810017902");
+    public static final ParticipantIdentifier U4_TEST = ParticipantIdentifier.of("0192:810017902");
 
 
-    public static final ParticipantIdentifier DIFI = ParticipantIdentifier.of("9908:991825827");
+    public static final ParticipantIdentifier DIFI = ParticipantIdentifier.of("0192:991825827");
 
     /**
      * Use this in test mode
      */
-    public static final ParticipantIdentifier DIFI_TEST = ParticipantIdentifier.of("9908:810418052");
+    public static final ParticipantIdentifier DIFI_TEST = ParticipantIdentifier.of("0192:810418052");
 
     /**
      * Random endpoint in test mode
@@ -49,6 +49,6 @@ public class WellKnownParticipant {
     /**
      * Old organisation number for Balder Treindustri
      */
-    public static final ParticipantIdentifier DUMMY = ParticipantIdentifier.of("9908:976098897");
+    public static final ParticipantIdentifier DUMMY = ParticipantIdentifier.of("0192:976098897");
 
 }


### PR DESCRIPTION
## Pull Request Description

Validating participant ids received from SBDH so their length and other caracteristics are enforced before attempting to process the message any further. 
This change is motivated because we received obviously invalid receiver participant Id that were causing failure in persistence for oxalis-ng-statistics, i.e. `Data too long for column 'receiver' ` 

## Type of Pull Request

- [x] New feature/Enhancement - non-breaking change which adds functionality
- [ ] Bug fix 
- [ ] Breaking change (Require Major version change?)

## Type of Change

- [ ] OpenPeppol eDEC Specifications
- [ ] Peppol AS4 Profile specification
- [x] Peppol Business Envelope specification
- [ ] Peppol Policies specification
- [ ] Peppol eDEC Code Lists specification
- [ ] OpenPeppol Spring/Fall release 
- [ ] Oxalis software internal change or enhancement
- [ ] General change

## Pull Request Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas. But did not add unnecessary annotation/comment say @author name etc
- [x] I have checked my code for variable and method name and corrected grammar/spelling mistakes if any
- [x] I have made corresponding changes to the documentation where needed
- [ ] My changes generate no new/additional warnings
- [x] My change is not breaking or creating conflict with associated dependencies 
- [x] I have performed a self-review of my own code
- [x] I ran `mvn clean install` before commit and all tests run successfully 
- [x] I conducted basic QA to assure all features are working fine
- [x] My pull request generate no conflicts with `master` branch
- [x] I requested code review from other team members
