### PR TITLE
Fix unbounded memory leak in `OxalisAlgorithmSuiteLoader` (static `BUS_MAP`)

### DIFF
--- a/oxalis-ng-extension/oxalis-ng-as4/src/main/java/network/oxalis/ng/as4/util/OxalisAlgorithmSuiteLoader.java
+++ b/oxalis-ng-extension/oxalis-ng-as4/src/main/java/network/oxalis/ng/as4/util/OxalisAlgorithmSuiteLoader.java
@@ -19,7 +19,6 @@ import org.w3c.dom.Element;
 import javax.xml.namespace.QName;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 
 import static org.apache.wss4j.common.WSS4JConstants.MGF_SHA256;
 
@@ -34,22 +33,16 @@ public class OxalisAlgorithmSuiteLoader implements AlgorithmSuiteLoader {
     public static final String BASIC_128_GCM_SHA_256 = "Basic128GCMSha256";
     public static final String BASIC_128_GCM_SHA_256_MGF_SHA_256 = "Basic128GCMSha256MgfSha256";
 
-    private static final Map<String, Bus> BUS_MAP = new ConcurrentHashMap<>();
-
     public OxalisAlgorithmSuiteLoader(final Bus bus) {
-        BUS_MAP.computeIfAbsent(bus.getId(), id -> {
-            AlgorithmSuiteLoader algorithmSuiteLoader = bus.getExtension(AlgorithmSuiteLoader.class);
+        AlgorithmSuiteLoader algorithmSuiteLoader = bus.getExtension(AlgorithmSuiteLoader.class);
 
-            if (algorithmSuiteLoader instanceof OxalisAlgorithmSuiteLoader) {
-                log.info("Cached OxalisAlgorithmSuite on bus {}", bus.getId());
-            } else {
-                log.info("Registering OxalisAlgorithmSuite on bus {}", bus.getId());
-                bus.setExtension(this, AlgorithmSuiteLoader.class);
-                register(bus);
-            }
-
-            return bus;
-        });
+        if (algorithmSuiteLoader instanceof OxalisAlgorithmSuiteLoader) {
+            log.info("OxalisAlgorithmSuite already registered on bus {}", bus.getId());
+        } else {
+            log.info("Registering OxalisAlgorithmSuite on bus {}", bus.getId());
+            bus.setExtension(this, AlgorithmSuiteLoader.class);
+            register(bus);
+        }
     }
 
     public AlgorithmSuite getAlgorithmSuite(final Bus bus, final SPConstants.SPVersion version, final Policy nestedPolicy) {

--- a/oxalis-ng-extension/oxalis-ng-as4/src/test/java/network/oxalis/ng/as4/util/OxalisAlgorithmSuiteLoaderTest.java
+++ b/oxalis-ng-extension/oxalis-ng-as4/src/test/java/network/oxalis/ng/as4/util/OxalisAlgorithmSuiteLoaderTest.java
@@ -1,0 +1,134 @@
+package network.oxalis.ng.as4.util;
+
+import org.apache.cxf.Bus;
+import org.apache.cxf.bus.extension.ExtensionManagerBus;
+import org.apache.cxf.ws.policy.AssertionBuilderRegistry;
+import org.apache.cxf.ws.security.policy.custom.AlgorithmSuiteLoader;
+import org.testng.annotations.Test;
+
+import java.lang.ref.WeakReference;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.testng.Assert.*;
+
+/**
+ * Tests for the memory-leak fix in {@link OxalisAlgorithmSuiteLoader}.
+ *
+ * <p>Background: the constructor previously kept a {@code private static final
+ * Map<String, Bus> BUS_MAP} keyed on the unique {@link Bus#getId()} and stored the Bus as the
+ * value, never evicting. Callers that create a fresh CXF Bus per request (e.g. peppol-outbound,
+ * to avoid CXF feature accumulation) therefore pinned an entire Bus graph per request, leaking
+ * memory until the process was OOM-killed.
+ *
+ * <p>The fix removes the static map and relies on the per-Bus extension
+ * ({@code bus.getExtension(AlgorithmSuiteLoader.class)}) for idempotency, so a Bus becomes
+ * eligible for GC as soon as the caller releases it.
+ */
+public class OxalisAlgorithmSuiteLoaderTest {
+
+    @Test
+    public void registersAlgorithmSuiteLoaderAsBusExtension() {
+        Bus bus = new ExtensionManagerBus();
+
+        new OxalisAlgorithmSuiteLoader(bus);
+
+        AlgorithmSuiteLoader registered = bus.getExtension(AlgorithmSuiteLoader.class);
+        assertTrue(registered instanceof OxalisAlgorithmSuiteLoader,
+                "OxalisAlgorithmSuiteLoader must be registered as the bus AlgorithmSuiteLoader extension");
+        assertNotNull(bus.getExtension(AssertionBuilderRegistry.class).getBuilder(
+                new javax.xml.namespace.QName(
+                        OxalisAlgorithmSuiteLoader.OXALIS_ALGORITHM_NAMESPACE,
+                        OxalisAlgorithmSuiteLoader.BASIC_128_GCM_SHA_256)),
+                "Custom Basic128GCMSha256 assertion builder must be registered on the bus");
+    }
+
+    @Test
+    public void isIdempotentPerBus_keepsFirstExtensionInstance() {
+        Bus bus = new ExtensionManagerBus();
+
+        new OxalisAlgorithmSuiteLoader(bus);
+        AlgorithmSuiteLoader first = bus.getExtension(AlgorithmSuiteLoader.class);
+
+        // Constructing again for the same bus must NOT replace the already-registered extension.
+        new OxalisAlgorithmSuiteLoader(bus);
+        AlgorithmSuiteLoader second = bus.getExtension(AlgorithmSuiteLoader.class);
+
+        assertSame(second, first,
+                "Re-registering on the same bus must keep the existing extension (idempotent)");
+    }
+
+    @Test
+    public void eachBusGetsItsOwnLoaderRegistered() {
+        Bus busA = new ExtensionManagerBus();
+        Bus busB = new ExtensionManagerBus();
+
+        new OxalisAlgorithmSuiteLoader(busA);
+        new OxalisAlgorithmSuiteLoader(busB);
+
+        assertTrue(busA.getExtension(AlgorithmSuiteLoader.class) instanceof OxalisAlgorithmSuiteLoader);
+        assertTrue(busB.getExtension(AlgorithmSuiteLoader.class) instanceof OxalisAlgorithmSuiteLoader);
+        assertNotSame(busA.getExtension(AlgorithmSuiteLoader.class),
+                busB.getExtension(AlgorithmSuiteLoader.class),
+                "Distinct buses must each carry their own loader extension");
+    }
+
+    /**
+     * Core leak-regression test: a Bus that has had an OxalisAlgorithmSuiteLoader registered must
+     * become garbage-collectable once the caller drops its reference. With the old static BUS_MAP
+     * the Bus stayed strongly reachable forever and this assertion failed.
+     */
+    @Test
+    public void busIsGarbageCollectableAfterLoaderRegistered() throws Exception {
+        Bus bus = new ExtensionManagerBus();
+        new OxalisAlgorithmSuiteLoader(bus);
+
+        WeakReference<Bus> ref = new WeakReference<>(bus);
+        bus.shutdown(true);
+        bus = null; // drop the only strong reference
+
+        assertTrue(awaitCollected(ref),
+                "Bus must be GC-eligible after the caller releases it; a lingering reference "
+                        + "(e.g. a static map) would keep the entire Bus graph alive and leak memory");
+    }
+
+    /**
+     * Simulates the peppol-outbound per-message pattern: create many fresh buses, register the
+     * loader on each, then release them. None must remain strongly reachable.
+     */
+    @Test
+    public void manyFreshBusesAreAllCollectable() throws Exception {
+        int count = 200;
+        List<WeakReference<Bus>> refs = new ArrayList<>(count);
+
+        for (int i = 0; i < count; i++) {
+            Bus bus = new ExtensionManagerBus();
+            new OxalisAlgorithmSuiteLoader(bus);
+            refs.add(new WeakReference<>(bus));
+            bus.shutdown(true);
+            // bus goes out of scope at end of iteration
+        }
+
+        long collected = 0;
+        for (int attempt = 0; attempt < 20 && collected < count; attempt++) {
+            System.gc();
+            Thread.sleep(50);
+            collected = refs.stream().filter(r -> r.get() == null).count();
+        }
+
+        assertEquals(collected, count,
+                "All " + count + " per-message buses must be collectable; "
+                        + (count - collected) + " were still pinned (memory leak)");
+    }
+
+    private static boolean awaitCollected(WeakReference<?> ref) throws InterruptedException {
+        for (int attempt = 0; attempt < 20; attempt++) {
+            System.gc();
+            Thread.sleep(50);
+            if (ref.get() == null) {
+                return true;
+            }
+        }
+        return false;
+    }
+}


### PR DESCRIPTION
## Pull Request Description

Fixes an unbounded memory leak in `OxalisAlgorithmSuiteLoader`.

The class held a `private static final Map<String, Bus> BUS_MAP` that was keyed on the
unique `bus.getId()` and stored the `Bus` itself as the value, and never evicted any entry.
Callers that create a fresh CXF `Bus` per message (a common pattern to isolate AS4 sends)
therefore pinned an entire `Bus` graph — `PhaseManager`, `PolicyEngine`, `WSDLManager`, all
WS-Security interceptor providers — in that static map on every message. The map only ever
grew (unique key per bus) and `bus.shutdown()` did not remove the entry, so memory grew
linearly until the JVM/container was OOM-killed.

Verified with heap-dump diffs: after 500 messages the heap retained 501 `ExtensionManagerBus`
instances (one per message); a path-to-GC-root analysis pointed to `BUS_MAP` as the single
root.

The fix removes `BUS_MAP` and relies on the per-bus extension that the constructor already
registers (`bus.getExtension(AlgorithmSuiteLoader.class)`), which already guarantees the suite
is registered at most once per bus. The extension lives on the `Bus`, so it is garbage-collected
together with the bus instead of being pinned statically. Adds `OxalisAlgorithmSuiteLoaderTest` with
registration, per-bus idempotency and two GC-collectability regression tests.

## Type of Pull Request

- [ ] New feature/Enhancement - non-breaking change which adds functionality
- [x] Bug fix 
- [ ] Breaking change (Require Major version change?)

## Type of Change

- [ ] OpenPeppol eDEC Specifications
- [ ] Peppol AS4 Profile specification
- [ ] Peppol Business Envelope specification
- [ ] Peppol Policies specification
- [ ] Peppol eDEC Code Lists specification
- [ ] OpenPeppol Spring/Fall release 
- [x] Oxalis software internal change or enhancement
- [ ] General change

## Pull Request Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas. But did not add unnecessary annotation/comment say @author name etc
- [x] I have checked my code for variable and method name and corrected grammar/spelling mistakes if any
- [ ] I have made corresponding changes to the documentation where needed
- [x] My changes generate no new/additional warnings
- [x] My change is not breaking or creating conflict with associated dependencies 
- [x] I have performed a self-review of my own code
- [x] I ran `mvn clean install` before commit and all tests run successfully 
- [x] I conducted basic QA to assure all features are working fine
- [x] My pull request generate no conflicts with `master` branch
- [ ] I requested code review from other team members